### PR TITLE
Set matplotlib backend

### DIFF
--- a/Animation.py
+++ b/Animation.py
@@ -25,6 +25,10 @@ __title__="FreeCAD Animation Toolkit"
 __author__ = "Thomas Gundermann"
 __url__ = "http://www.freecadbuch.de"
 
+import matplotlib
+matplotlib.use('Qt4Agg')
+matplotlib.rcParams['backend.qt4']='PySide'
+
 import FreeCAD, Part, PartGui, Draft, Drawing , PySide
 from FreeCAD import Vector,Base
 import math, os, sys


### PR DESCRIPTION
When not set before for example doing:

```python
import matplotlib.pyplot as plt
```

It looks like it affects other modules like Plot. TkAgg being used instead.

```python
import Plot
```

If merged check other parts of Animation module using Matplotlib for possible regressions. Read more on forum:

Forum discussion: 
https://forum.freecadweb.org/viewtopic.php?f=22&t=27013&p=217724#p217724